### PR TITLE
remove qs.escape in Message.payload

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -1,5 +1,3 @@
-var qs = require('querystring');
-
 var Message = function() {
   this._data = {};
   return this;
@@ -10,7 +8,7 @@ var Message = function() {
  * 不允许全是空白字符, 长度小于4K, 中英文均以一个计算.
  */
 Message.prototype.payload = function(payload) {
-  return this.set('payload', qs.escape(payload));
+  return this.set('payload', payload);
 };
 
 /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaomi-push",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "小米推送服务端Node SDK",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaomi-push",
-  "version": "0.4.5",
+  "version": "0.4.4",
   "description": "小米推送服务端Node SDK",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
qs.escape 放在 request body 里面好像没有用
而且会做多余的事，比如使用 payload 传一个 stringify JSON 时，里面的双引号会被 escape，导致客户端解析出现问题