### PR TITLE
Support xmpush global server and new API version v3 & v4

### DIFF
--- a/lib/constant.js
+++ b/lib/constant.js
@@ -10,12 +10,12 @@ module.exports = {
   tracerMessageAPI: production + '/v1/trace/message/status',
   tracerMessagesAPI: production + '/v1/trace/messages/status',
   notificationAPI: {
-    regid: production + '/v2/message/regid',
-    alias: production + '/v2/message/alias',
+    regid: production + '/v4/message/regid',
+    alias: production + '/v3/message/alias',
     account: production + '/v2/message/user_account',
-    topic: production + '/v2/message/topic',
-    multitopic: production + '/v2/message/multi_topic',
-    all: production + '/v2/message/all'
+    topic: production + '/v3/message/topic',
+    multitopic: production + '/v3/message/multi_topic',
+    all: production + '/v3/message/all'
   },
   notificationSandboxAPI: {
     regid: sandbox + '/v2/message/regid',

--- a/lib/feedback.js
+++ b/lib/feedback.js
@@ -13,6 +13,11 @@ var Feedback = function (options) {
 
   utils.parseOptions.call(this, options)
 
+  // convert to global url
+  if (this.options.global) {
+    feedbackAPI = feedbackAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+  }
+
   EventEmitter.call(this)
 
   return this

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -17,6 +17,13 @@ var Notification = function (options) {
     this.apis = _.clone(constant.notificationSandboxAPI)
   }
 
+  // convert to global url
+  if (this.options.global) {
+    _.each(this.apis, (url, key) => {
+      this.apis[key] = url.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+    })
+  }
+
   return this
 }
 

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -14,6 +14,13 @@ var Stats = function (options) {
     requirePackageName: true
   })
 
+    // convert to global url
+    if (this.options.global) {
+      statsAPI = statsAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+      aliasStatsAPI = aliasStatsAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+      topicStatsAPI = topicStatsAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+    }
+
   return this
 }
 

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -16,6 +16,13 @@ var Subscription = function (options) {
     this.apis = _.clone(constant.tracerSandboxAPI)
   }
 
+  // convert to global url
+  if (this.options.global) {
+    _.each(this.apis, (url, key) => {
+      this.apis[key] = url.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+    })
+  }
+  
   return this
 }
 

--- a/lib/tracer.js
+++ b/lib/tracer.js
@@ -11,6 +11,11 @@ var Tracer = function (options) {
 
   utils.parseOptions.call(this, options)
 
+  // convert to global url
+  if (this.options.global) {
+    tracerMessageAPI = tracerMessageAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+    tracerMessagesAPI = tracerMessagesAPI.replace('xmpush.xiaomi', 'xmpush.global.xiaomi');
+  }
   return this
 }
 


### PR DESCRIPTION
Details see xmpush doc: https://dev.mi.com/console/doc/detail?pId=1163

V4版接口（支持同时发送消息到国内和海外）：
向某个regid或一组regid列表推送某条消息，适用于服务器部署在国内时，同时向国内和海外目标设备推送消息
https://api.xmpush.xiaomi.com/v4/message/regid
向某个regid或一组regid列表推送某条消息，适用于服务器部署在海外时，同时向国内和海外目标设备推送消息
https://api.xmpush.global.xiaomi.com/v4/message/regid